### PR TITLE
修正ListFilesAsync接口pageSize参数别名

### DIFF
--- a/RAGFlowSharp/Api/IFileApi.cs
+++ b/RAGFlowSharp/Api/IFileApi.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 using RAGFlowSharp.Dtos.File;
+using WebApiClientCore;
 using WebApiClientCore.Attributes;
 
 namespace RAGFlowSharp.Api
@@ -66,7 +67,7 @@ namespace RAGFlowSharp.Api
         Task<List.ResponseBody> ListFilesAsync(
             [PathQuery] string datasetId,
             [PathQuery] int? page = null,
-            [PathQuery] int? pageSize = null,
+            [AliasAs("page_size")][PathQuery] int? pageSize = null,
             [PathQuery] string? orderBy = null,
             [PathQuery] bool? desc = null,
             [PathQuery] string? keywords = null,


### PR DESCRIPTION
- 在ListFilesAsync方法中为pageSize参数添加AliasAs特性，名称为page_size
- 确保HTTP请求查询参数与后端API保持一致